### PR TITLE
fix error send transaction format

### DIFF
--- a/apps/mobile/app/(auth)/home/send/index.tsx
+++ b/apps/mobile/app/(auth)/home/send/index.tsx
@@ -130,8 +130,8 @@ export default function TransferScreen() {
         const availableBalance = isNativeToken ? balance?.formatted.transferable : tokenBalance;
 
         // Clean the formatted balance string by removing commas and other formatting
-        const cleanAvailableBalance = availableBalance?.replace(/,/g, "") || "0";
-        const cleanDisplayValue = displayValue.replace(/,/g, "");
+        const cleanAvailableBalance = availableBalance?.replace(/[^\d.]/g, "") || "0";
+        const cleanDisplayValue = displayValue.replace(/[^\d.]/g, "");
 
         if (!displayValue || !recipient) {
             Dialog.show({

--- a/apps/mobile/app/(auth)/home/send/index.tsx
+++ b/apps/mobile/app/(auth)/home/send/index.tsx
@@ -129,6 +129,10 @@ export default function TransferScreen() {
     const sendTransaction = async () => {
         const availableBalance = isNativeToken ? balance?.formatted.transferable : tokenBalance;
 
+        // Clean the formatted balance string by removing commas and other formatting
+        const cleanAvailableBalance = availableBalance?.replace(/,/g, "") || "0";
+        const cleanDisplayValue = displayValue.replace(/,/g, "");
+
         if (!displayValue || !recipient) {
             Dialog.show({
                 type: ALERT_TYPE.WARNING,
@@ -143,7 +147,7 @@ export default function TransferScreen() {
                 textBody: "Invalid amount",
                 button: "Close",
             });
-        } else if (parseFloat(displayValue) > parseFloat(availableBalance || "0")) {
+        } else if (parseFloat(cleanDisplayValue) > parseFloat(cleanAvailableBalance)) {
             Dialog.show({
                 type: ALERT_TYPE.WARNING,
                 title: "Attention",


### PR DESCRIPTION
This pull request includes updates to the `TransferScreen` component in `apps/mobile/app/(auth)/home/send/index.tsx` to ensure proper handling of formatted balance strings during transaction validation.

Changes to improve validation logic:

* Added logic to clean the `availableBalance` and `displayValue` strings by removing commas and other formatting before parsing them for numerical comparison. This prevents errors when validating transaction amounts.
* Updated the comparison logic to use the cleaned balance and display values (`cleanAvailableBalance` and `cleanDisplayValue`) for validating whether the transaction amount exceeds the available balance.